### PR TITLE
Fix SyncStatus typo

### DIFF
--- a/src/services/syncManager.ts
+++ b/src/services/syncManager.ts
@@ -308,7 +308,7 @@ class SyncManager {
       isOnline: this.isOnline,
       lastSync,
       pendingChanges,
-      isSimcing: this.syncInProgress,
+      isSyncing: this.syncInProgress,
       syncProgress: 0, // TODO: реализовать расчет прогресса
       errors: []
     };
@@ -319,7 +319,7 @@ class SyncManager {
       isOnline: this.isOnline,
       lastSync: null,
       pendingChanges: 0,
-      isSimcing: this.syncInProgress,
+      isSyncing: this.syncInProgress,
       syncProgress: 0,
       errors: []
     };

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -40,7 +40,7 @@ export interface SyncStatus {
   isOnline: boolean;
   lastSync: number | null;
   pendingChanges: number;
-  isSimcing: boolean;
+  isSyncing: boolean;
   syncProgress: number;
   errors: SyncError[];
 }


### PR DESCRIPTION
## Summary
- fix a typo in `SyncStatus.isSyncing`

## Testing
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_687a2d64de78832f8913a54be2c3a5de